### PR TITLE
feat(basic-memory): add version pinning support

### DIFF
--- a/registry/mcp-servers/basic-memory/claude.md
+++ b/registry/mcp-servers/basic-memory/claude.md
@@ -4,8 +4,12 @@
 
 **File Conventions** (CRITICAL):
 
-- **Titles**: kebab-case filenames (e.g., `authentication-flow`, `api-design-patterns`)
-- **Frontmatter**: Title Case in YAML `title` field
+- **Titles**: ALWAYS use kebab-case for the `title` parameter in `write_note()` (e.g., `authentication-flow`, `api-design-patterns`)
+  - The `title` parameter becomes the exact filename - no automatic conversion
+  - NEVER use spaces or Title Case in titles - use kebab-case only
+  - Example: `write_note(title="authentication-flow", ...)` creates `authentication-flow.md`
+  - Wrong: `write_note(title="Authentication Flow", ...)` creates `Authentication Flow.md` (spaces in filename)
+- **Frontmatter**: The frontmatter `title` field will match your kebab-case title parameter
 - **Access**: ALL operations through MCP tools only, NEVER direct file edits
 - **Format**: Run Prettier on content before writing: `echo "$content" | npx prettier --parser markdown`
 
@@ -14,7 +18,7 @@
 ```
 features/         # Feature documentation (not prefixed with issue numbers, may span multiple issues)
 guides/           # How-to documentation and usage instructions
-plans/            # Issue-specific task management with status tracking (prefixed with issue-N-)
+issues/           # Work tracked in GitHub/Jira/etc (prefixed with NNN- when ticket assigned)
 notes/            # Project-specific documentation
 technologies/     # Technical documentation and architecture
 meetings/         # Meeting notes and transcripts (YYYY-MM-DDTHH-MM-SS_topic.md)
@@ -31,17 +35,19 @@ Document implemented features without issue number prefixes. Features may span m
 - related-to: [[issue-12-version-caching]]
 ```
 
-**Plan Files** (`plans/` folder):
-Multi-phase task tracking with status indicators and detailed work items:
+**Issue Files** (`issues/` folder):
+Multi-phase task tracking with status indicators and detailed work items. Prefix with ticket number (001-, 006-, etc.) when assigned from GitHub/Jira/etc:
 
 ```markdown
 ---
+title: "Issue NNN: Task Description"
 kind: Plan
 created_at: 2025-01-15T10:30:00.000Z
 status: active # draft | active | complete
+issue_permalink: https://github.com/org/repo/issues/NNN
 ---
 
-# Plan
+# Issue NNN: Task Description
 
 ## ✅ COMPLETED — Phase 1 Name
 
@@ -60,12 +66,13 @@ status: active # draft | active | complete
 - [ ] Another upcoming task
 ```
 
-**Plan Management**:
+**Issue Management**:
 
 - Use Sequential (if available) to break down complex objectives into phases
-- Update plan status as work progresses (📌 BACKLOG → ⏳ IN PROGRESS → ✅ COMPLETED)
+- Update status as work progresses (📌 BACKLOG → ⏳ IN PROGRESS → ✅ COMPLETED)
 - Edit notes to check off tasks `[x]` and add discovered work items
-- Plans track multi-session objectives, not single-session todos
+- Issues track multi-session objectives, not single-session todos
+- Prefix filename with ticket number (001-, 006-) when assigned from project management system
 
 **Required Metadata** (append to all notes):
 
@@ -87,7 +94,7 @@ status: active # draft | active | complete
 
 1. Search existing notes before creating new ones
 2. Use `build_context` for gathering related notes
-3. Create plan files in `plans/` for multi-step work
+3. Create issue files in `issues/` for multi-step work
 4. Always include observations + relations sections
 5. Format with Prettier before writing
 
@@ -95,7 +102,7 @@ status: active # draft | active | complete
 
 **Cooperation with Other MCPs**:
 
-- Sequential: Track complex multi-step processes in `plan/*.md` note
+- Sequential: Track complex multi-step processes in `issues/*.md` note
 - Exa: Conduct deep research, then document raw results in a `research/*.md` note
 - Context7: Capture key patterns from official docs in notes
 - Firecrawl: Store raw page content with source attribution in `sites/domain/path/*.md` files

--- a/registry/mcp-servers/basic-memory/index.ts
+++ b/registry/mcp-servers/basic-memory/index.ts
@@ -18,7 +18,8 @@ export class BasicMemoryServer extends BaseMCPServer {
     name: "Basic Memory",
     description: "Persistent memory and note-taking capabilities for Claude Code",
     category: "core",
-    version: "1.0.0",
+    packageName: "basic-memory",
+    packageRegistry: "pypi",
     homepage: "https://github.com/cyanheads/basic-memory",
   };
 
@@ -109,16 +110,18 @@ export class BasicMemoryServer extends BaseMCPServer {
     }
   }
 
-  protected override generateMcpConfig(_secrets: Record<string, string>, _version?: string) {
+  protected override generateMcpConfig(_secrets: Record<string, string>, version?: string) {
     // Get the project name from the current directory
     const cwd = Deno.cwd();
     const projectName = cwd.split("/").pop() || "fluent-toolkit";
 
-    // Basic Memory uses custom command, version parameter ignored
+    // Build package spec with optional version pinning (uvx format: package==version)
+    const packageSpec = version ? `basic-memory==${version}` : "basic-memory";
+
     return {
       command: "uvx",
       args: [
-        "basic-memory",
+        packageSpec,
         "mcp",
         `--project=${projectName}`,
       ],


### PR DESCRIPTION
## Summary

Adds version pinning support to Basic Memory MCP server, completing Phase 3 of Issue #6.

## Changes

### Basic Memory Server Configuration

**Added package registry metadata:**
```typescript
packageName: "basic-memory",
packageRegistry: "pypi",
```

**Updated generateMcpConfig for version pinning:**
```typescript
// Before
args: ["basic-memory", "mcp", "--project=..."]

// After  
const packageSpec = version ? `basic-memory==${version}` : "basic-memory";
args: [packageSpec, "mcp", "--project=..."]
```

### Documentation Improvements (claude.md)

- Renamed `plans/` → `issues/` for clarity
- Enhanced kebab-case title conventions with examples
- Added explicit warnings against using spaces in titles
- Better examples of correct vs incorrect usage

## How Version Pinning Works

1. **Version Resolution**: `BaseMCPServer.resolveVersion()` queries PyPI for latest version
2. **Lock File Storage**: Version stored in `mcp.lock.json` with constraint
3. **Config Generation**: `.mcp.json` updated with pinned version: `basic-memory==0.13.5`
4. **Reproducibility**: Future installs use locked version for consistency

## Testing

```bash
# Manual testing
ftk init
# Select Basic Memory
# Observe version resolution and pinning

# Validation
just validate  # All checks pass ✅
```

## Related

- Part of Issue #6: Pin MCP Server Versions
- Infrastructure from: feat/006-pin-mcp-server-versions (Phase 1 & 2)
- See: `context/basic-memory/issues/006-pin-mcp-server-versions.md`

## Checklist

- [x] Added packageName and packageRegistry to metadata
- [x] Updated generateMcpConfig to use version parameter
- [x] Tested with PyPI version resolution
- [x] Documentation improvements
- [x] All validation checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>